### PR TITLE
better describe the /ping endpoint with a summary field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 node_modules/
 dist/
-public/openapi.yml
-public/schemas
-
+public
 

--- a/endpoints/ping.yml
+++ b/endpoints/ping.yml
@@ -1,6 +1,7 @@
 paths:
     '/ping':
         get:
+          summary: Healthcheck endpoint
           operationId: ping
           description: "Check to see that the application is ready to respond to requests."
           tags:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "node_modules/.bin/speccy lint openapi.yml -j",
     "resolve": "mkdir -p dist && node_modules/.bin/speccy resolve openapi.yml -j > dist/openapi.yml",
     "serve": "node_modules/.bin/speccy serve openapi.yml -j",
-    "publish": "cp dist/openapi.yml public/openapi.yml && cp -R schemas public/"
+    "publish": "mkdir public && cp static/* public/ && cp dist/openapi.yml public/openapi.yml && cp -R schemas public/"
   },
   "repository": {
     "type": "git",

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Example Library Specification</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='/openapi.yml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>


### PR DESCRIPTION
Use the OpenAPI `summary` field in an operation to better describe the GET /ping operation.

