### PR TITLE
better describe the /ping endpoint with a summary field 

### DIFF
--- a/endpoints/ping.yml
+++ b/endpoints/ping.yml
@@ -1,6 +1,7 @@
 paths:
     '/ping':
         get:
+          summary: Healthcheck endpoint
           operationId: ping
           description: "Check to see that the application is ready to respond to requests."
           tags:


### PR DESCRIPTION
Use the OpenAPI summary field in an Operation to better describe the GET /ping operation.

